### PR TITLE
Add onError to scriptOptions

### DIFF
--- a/docs/props.mdx
+++ b/docs/props.mdx
@@ -56,3 +56,4 @@ These are the props you can pass to the `Turnstile` component.
 | `async`              | boolean  | `true`                      | Define if set the injected script as async.  This option has no effect if `injectScript` is set to false.             |
 | `appendTo`           | string   | `'head'`                    | Define if inject the script in the head or in the body.  This option has no effect if `injectScript` is set to false. |
 | `onLoadCallbackName` | string   | `'onloadTurnstileCallback'` | Custom name of the onload callback.  This option has no effect if `injectScript` is set to false.                     |
+| `onError`            | function | `undefined`                 | Callback invoked when script fails to load (e.g. Cloudflare has an outage).                                           |

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -266,6 +266,11 @@ interface ScriptOptions {
 	 * @default `onloadTurnstileCallback`
 	 */
 	onLoadCallbackName?: string
+
+	/**
+	 * Called if script fails to load (e.g. Cloudflare has an outage).
+	 */
+	onError?: () => void
 }
 
 /** `<Turnstile />` component props */

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -268,7 +268,7 @@ interface ScriptOptions {
 	onLoadCallbackName?: string
 
 	/**
-	 * Called if script fails to load (e.g. Cloudflare has an outage).
+	 * Callback invoked when script fails to load (e.g. Cloudflare has an outage).
 	 */
 	onError?: () => void
 }

--- a/packages/lib/src/utils.ts
+++ b/packages/lib/src/utils.ts
@@ -22,7 +22,7 @@ export const checkElementExistence = (id: string) => !!document.getElementById(i
 export const injectTurnstileScript = ({
 	render = 'explicit',
 	onLoadCallbackName = DEFAULT_ONLOAD_NAME,
-	scriptOptions: { nonce = '', defer = true, async = true, id = '', appendTo } = {}
+	scriptOptions: { nonce = '', defer = true, async = true, id = '', appendTo, onError } = {}
 }: InjectTurnstileScriptParams) => {
 	const scriptId = id || DEFAULT_SCRIPT_ID
 
@@ -45,6 +45,10 @@ export const injectTurnstileScript = ({
 
 	if (nonce) {
 		script.nonce = nonce
+	}
+
+	if (onError) {
+		script.onerror = onError
 	}
 
 	const parentEl = appendTo === 'body' ? document.body : document.getElementsByTagName('head')[0]


### PR DESCRIPTION
Closes https://github.com/marsidev/react-turnstile/issues/40

This adds an `onError` option to `scriptOptions`, which adds an `onerror` to the script that is injected into the DOM, so that devs can handle failures to load the Cloudflare script, such as when Cloudflare workers, turnstile, and pages recently were down for 25 minutes.

I wasn't able to test the docs locally, since pages.dev has an issue with local previews, but I _think_ it'll just get picked up automatically?