### PR TITLE
fix: collapse container height when appearance set to interaction-only

### DIFF
--- a/packages/lib/src/utils.ts
+++ b/packages/lib/src/utils.ts
@@ -99,7 +99,8 @@ export const CONTAINER_STYLE_SET: ContainerSizeSet = {
 	},
 	interactionOnly: {
 		width: 'fit-content',
-		height: 'auto'
+		height: 'auto',
+		display: 'flex'
 	}
 }
 


### PR DESCRIPTION
### Description
When the `appearance` is set to `interaction-only`, the container's height is set to `height: '0px'`, yet it occupies 24px of height, visible as empty space, even though the children div also have `height: 0px`.

This fix addresses the issue by adding `display: flex` to the container height for `appearance: interaction-only`. This change collapses the parent container height if the children have no height.

### Changes Made
- Added `display: flex` to the container height for `appearance: interaction-only`.

### Visual Comparison
| Before Fix  | After Fix | After Fix When Visible |
|-----------------|-----------------|-----------------|
|  ![turnstile-before](https://github.com/marsidev/react-turnstile/assets/5669143/6479e159-fc7c-40f4-9626-8061ec9feba7)  | ![turnstile-after](https://github.com/marsidev/react-turnstile/assets/5669143/c2006c20-3b80-45e4-86e3-04453dcefd3d)    | ![turnstile-after-visible](https://github.com/marsidev/react-turnstile/assets/5669143/17c9bb83-637d-45c8-a101-9fa0af4e3b0e)    |
 Container Height = 24px  | Container Height = 0px | Container Height = 65px |

### Additional Notes
- The turnstile container will still change to the rendered height depending on `size`.


