### PR TITLE
fix: update server-side validation response types

### DIFF
--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -410,7 +410,7 @@ interface TurnstileServerValidationResponse {
 	/** Indicate if the token validation was successful or not. */
 	success: boolean
 	/** A list of errors that occurred. */
-	'error-codes': TurnstileServerValidationErrorCode[] | []
+	'error-codes': TurnstileServerValidationErrorCode[]
 	/** The ISO timestamp for the time the challenge was solved. */
 	challenge_ts?: string
 	/** The hostname for which the challenge was served. */

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -422,7 +422,7 @@ interface TurnstileServerValidationResponse {
 	/** Whether or not an interactive challenge was issued by Cloudflare */
 	metadata?: { interactive: boolean }
 	/** Error messages returned */
-	messages?: []
+	messages?: string[]
 }
 
 /**

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -409,16 +409,20 @@ type TurnstileTheme = 'light' | 'dark' | 'auto'
 interface TurnstileServerValidationResponse {
 	/** Indicate if the token validation was successful or not. */
 	success: boolean
+	/** A list of errors that occurred. */
+	'error-codes': TurnstileServerValidationErrorCode[] | []
 	/** The ISO timestamp for the time the challenge was solved. */
 	challenge_ts?: string
 	/** The hostname for which the challenge was served. */
 	hostname?: string
-	/** A list of errors that occurred. */
-	'error-codes'?: TurnstileServerValidationErrorCode[]
 	/** The customer widget identifier passed to the widget on the client side. This is used to differentiate widgets using the same sitekey in analytics. Its integrity is protected by modifications from an attacker. It is recommended to validate that the action matches an expected value. */
 	action?: string
 	/** The customer data passed to the widget on the client side. This can be used by the customer to convey state. It is integrity protected by modifications from an attacker. */
 	cdata?: string
+	/** Whether or not an interactive challenge was issued by Cloudflare */
+	metadata?: { interactive: boolean }
+	/** Error messages returned */
+	messages?: []
 }
 
 /**


### PR DESCRIPTION
### Description
Cloudflare returns extra properties not yet accounted for in `TurnstileServerValidationResponse` and the `error-codes` is always returned whether the validation is successful or not.

`messages` and `metadata` seem like they have been added to the response more recently but not yet documented in the [official server-side validation docs](https://developers.cloudflare.com/turnstile/get-started/server-side-validation/#accepted-parameters).

`metadata` is returned when validation is successful.

I am not quite sure of the purpose of `messages` so the comment isn't as detailed but it is only returned if validation fails.

### Changes Made
* Updated type for `error-codes` property so it is always required but can be an empty array.
* Added types for `messages` and `metadata`.

### Examples
<img width="365" alt="Screenshot 2024-02-16 at 11 52 00 PM" src="https://github.com/marsidev/react-turnstile/assets/5669143/000c58b0-7761-45d1-a50b-3d4a335412b0">

<img width="386" alt="Screenshot 2024-02-16 at 11 52 10 PM" src="https://github.com/marsidev/react-turnstile/assets/5669143/62083819-27f6-4737-a824-156e3636d8ec">
