### PR TITLE
Fix useImperativeHandle not grabbing new window.turnstile

### DIFF
--- a/packages/lib/src/lib.tsx
+++ b/packages/lib/src/lib.tsx
@@ -240,7 +240,7 @@ export const Turnstile = forwardRef<TurnstileInstance | undefined, TurnstileProp
 				}
 			}
 		},
-		[widgetId, options.execution, widgetSize, renderConfig, containerRef, checkIfTurnstileLoaded]
+		[widgetId, options.execution, widgetSize, renderConfig, containerRef, checkIfTurnstileLoaded, turnstileLoaded]
 	)
 
 	useEffect(() => {


### PR DESCRIPTION
Hi! I found a bug which only seem to be trigger from an odd case in our code. Unfortunately I'm not at the liberty to share an example currently.

`useImperativeHandle` grabs `window.turnstile` at the begining, however if Turnstile is loaded _after_ the callback, `window.turnstile` stays `undefined`. The fix is to add `turnstileLoaded` in the dependencies.