### PR TITLE
fix: 'use client'; banner that was no longer being output

### DIFF
--- a/packages/lib/tsup.config.ts
+++ b/packages/lib/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
 	clean: true,
 	dts: true,
 	minify: true,
-	treeshake: true,
+	treeshake: false,
 	splitting: false,
 	entry: ['src/index.ts'],
 	format: 'esm',


### PR DESCRIPTION
Currently, due to a rollup issue (https://github.com/egoist/tsup/issues/835#issuecomment-1594905290), the 'use client' directive specified in the banner is being removed. This prevents the Turnstile widget from being used directly in server components, such as those in Next.js.

To circumvent this problem, we can disable the treeshaking option, which prevents rollup from being used. 
However, please note that this comes with the trade-off of losing the ability to use treeshaking.