### PR TITLE
fix: update getResponsePromise return type to exclude undefined

### DIFF
--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -40,7 +40,7 @@ export interface TurnstileInstance extends Omit<Turnstile.Turnstile, 'ready'> {
 	getResponsePromise: (
 		timeout?: number,
 		retry?: number
-	) => Promise<ReturnType<Turnstile.Turnstile['getResponse']>>
+	) => Promise<ReturnType<Exclude<Turnstile.Turnstile['getResponse'], undefined>>>
 
 	/** Checks whether or not the token returned by the given widget is expired. */
 	isExpired: () => ReturnType<Turnstile.Turnstile['isExpired']>

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -40,7 +40,7 @@ export interface TurnstileInstance extends Omit<Turnstile.Turnstile, 'ready'> {
 	getResponsePromise: (
 		timeout?: number,
 		retry?: number
-	) => Promise<ReturnType<Exclude<Turnstile.Turnstile['getResponse'], undefined>>>
+	) => Promise<Exclude<ReturnType<Turnstile.Turnstile['getResponse']>, undefined>>
 
 	/** Checks whether or not the token returned by the given widget is expired. */
 	isExpired: () => ReturnType<Turnstile.Turnstile['isExpired']>


### PR DESCRIPTION
Thanks for this library! From my understanding getResponsePromise never resolves to undefined, unlike getResponse that can return undefined. Excluded undefined frmo types to better reflect resolved type

https://github.com/marsidev/react-turnstile/blob/d452f1ad052cf28e1d6d8ae5a1c9ac15c981f7dd/packages/lib/src/lib.tsx#L270