### PR TITLE
docs: add support for bun package manager in getting started guide

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -12,10 +12,12 @@ title: React Turnstile - Getting started
   values={[
     { label: 'npm', value: 'npm' },
     { label: 'pnpm', value: 'pnpm' },
+	{ label: 'bun', value: 'bun' },
     { label: 'yarn', value: 'yarn' },
     { label: 'ni', value: 'ni' },
   ]}
 >
+
   <TabItem value="npm">
     ```bash
     npm i @marsidev/react-turnstile
@@ -25,6 +27,12 @@ title: React Turnstile - Getting started
   <TabItem value="pnpm">
     ```bash
     pnpm add @marsidev/react-turnstile
+    ```
+  </TabItem>
+
+  <TabItem value="bun">
+    ```bash
+    bun add @marsidev/react-turnstile
     ```
   </TabItem>
 


### PR DESCRIPTION
Adds [Bun](https://bun.com/) as a supported package manager option in the [getting started guide](https://docs.page/marsidev/react-turnstile).

### Changes

- Added "bun" tab to the package manager installation options
- Included Bun installation command: `bun add @marsidev/react-turnstile`