### PR TITLE
fix: feedbackEnabled option cannot be set to false

### DIFF
--- a/packages/lib/src/lib.tsx
+++ b/packages/lib/src/lib.tsx
@@ -135,7 +135,7 @@ export const Turnstile = forwardRef<TurnstileInstance | undefined, TurnstileProp
 			'refresh-timeout': options.refreshTimeout || 'auto',
 			execution: options.execution || 'render',
 			appearance: options.appearance || 'always',
-			'feedback-enabled': options.feedbackEnabled || true,
+			'feedback-enabled': options.feedbackEnabled ?? true,
 			callback: token => {
 				widgetSolved.current = true
 				if (rerenderOnCallbackChange) {


### PR DESCRIPTION
`options.feedbackEnabled || true` always evaluates to `true` when `feedbackEnabled` is `false`. Replaced `||` with `??` to respect explicit `false`.