### PR TITLE
fix: stop passing params to turnstile.execute() (#129)

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marsidev/react-turnstile",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": false,
   "description": "Cloudflare Turnstile integration for React.",
   "keywords": [

--- a/packages/lib/src/lib.tsx
+++ b/packages/lib/src/lib.tsx
@@ -366,7 +366,7 @@ export const Turnstile = forwardRef<TurnstileInstance | undefined, TurnstileProp
           return;
         }
 
-        turnstile.execute(containerRef.current, renderConfig);
+        turnstile.execute(containerRef.current);
         setContainerStyle(widgetSize ? CONTAINER_STYLE_SET[widgetSize] : {});
       },
 


### PR DESCRIPTION
Closes #129. Released as v1.5.1 on npm.