### PR TITLE
chore: inline release prep steps to bypass npm ignore-scripts

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -41,8 +41,7 @@
   "scripts": {
     "build": "tsdown",
     "build:watch": "tsdown --watch",
-    "prepublishOnly": "copyfiles -u 2 ../../README.md . && pnpm run build",
-    "release": "bumpp && npm publish",
+    "release": "bumpp && copyfiles -u 2 ../../README.md . && pnpm run build && npm publish",
     "typecheck": "tsgo --noEmit",
     "test:integration": "vitest run",
     "test:integration:watch": "vitest"


### PR DESCRIPTION
## Summary

- Folded `prepublishOnly` (README copy + build) into the `release` script so the steps run via `pnpm run release` instead of relying on `npm publish` lifecycle hooks.
- Global `npm config ignore-scripts=true` was silently skipping `prepublishOnly`, which caused v1.5.1 to ship with a stale `packages/lib/README.md` (old badgen.net badges) on npm.