### PR TITLE
Add LICENSE to npm package

### DIFF
--- a/packages/lib/.gitignore
+++ b/packages/lib/.gitignore
@@ -1,2 +1,3 @@
 # Copied from root during publish
+LICENSE
 README.md

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -19,7 +19,6 @@
     "url": "git+https://github.com/marsidev/react-turnstile.git"
   },
   "files": [
-	"../../LICENSE",
     "dist",
     "skills",
     "!skills/_artifacts"
@@ -42,7 +41,7 @@
   "scripts": {
     "build": "tsdown",
     "build:watch": "tsdown --watch",
-    "release": "bumpp && copyfiles -u 2 ../../README.md . && pnpm run build && npm publish",
+    "release": "bumpp && copyfiles -u 2 ../../LICENSE . && copyfiles -u 2 ../../README.md . && pnpm run build && npm publish",
     "typecheck": "tsgo --noEmit",
     "test:integration": "vitest run",
     "test:integration:watch": "vitest"

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -19,6 +19,7 @@
     "url": "git+https://github.com/marsidev/react-turnstile.git"
   },
   "files": [
+	"../../LICENSE",
     "dist",
     "skills",
     "!skills/_artifacts"


### PR DESCRIPTION
Resolves #132 

~Devin (https://app.devin.ai/review/marsidev/react-turnstile/pull/133) says that npm ignores `files` entries that are out of the folder, so this won't do.~ Fixed