### PR TITLE
ci: run zizmor on all PRs so the required check always reports

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,17 +1,13 @@
 name: Zizmor
 
+# No `paths:` filter: this is a required status check, so it must run (and
+# report) on every PR. A path-filtered required check never reports on PRs that
+# don't touch the filtered paths, which blocks them from merging. Scanning the
+# unchanged workflows on every PR is cheap (~10s).
 on:
   pull_request:
-    paths:
-      - '.github/workflows/**'
-      - '.github/actions/**'
-      - '.github/zizmor.yml'
   push:
     branches: [main]
-    paths:
-      - '.github/workflows/**'
-      - '.github/actions/**'
-      - '.github/zizmor.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
Fixes a merge-blocking gotcha: `zizmor` is a **required** status check, but `zizmor.yml` was path-filtered to `.github/workflows/**`. PRs that don't touch those paths (e.g. Dependabot app-dependency bumps like #139) never get a zizmor run, so the required check stays pending and the PR can't merge.

Dropping the `paths:` filter makes zizmor run and report on every PR/push (~10s to re-scan unchanged workflows), so the required check is always satisfied while still gating any workflow changes.

After merge: 'Update branch' on any currently-blocked PR (e.g. #139) so the unfiltered zizmor runs on it.