### PR TITLE
chore: upgrade to pnpm 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
     "oxlint": "1.57.0",
     "oxlint-tsgolint": "0.17.4",
     "playwright": "1.58.2",
-    "pnpm": "10.33.0",
+    "pnpm": "11.0.8",
     "simple-git-hooks": "2.13.1"
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm check"
   },
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@11.0.8"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,8 +53,8 @@ importers:
         specifier: 1.58.2
         version: 1.58.2
       pnpm:
-        specifier: 10.33.0
-        version: 10.33.0
+        specifier: 11.0.8
+        version: 11.0.8
       simple-git-hooks:
         specifier: 2.13.1
         version: 2.13.1
@@ -2451,9 +2451,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  pnpm@10.33.0:
-    resolution: {integrity: sha512-EFaLtKavtYyes2MNqQzJUWQXq+vT+rvmc58K55VyjaFJHp21pUTHatjrdXD1xLs9bGN7LLQb/c20f6gjyGSTGQ==}
-    engines: {node: '>=18.12'}
+  pnpm@11.0.8:
+    resolution: {integrity: sha512-TECX4d0tQjcsTn+lp5H/KPx1pITHrBkuZLHfD97xdZS6mC+bT+2a37PHV4RvVlt5mydj+zcz0d4by4LPRmhJEg==}
+    engines: {node: '>=22.13'}
     hasBin: true
 
   postcss-selector-parser@6.0.10:
@@ -4934,7 +4934,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  pnpm@10.33.0: {}
+  pnpm@11.0.8: {}
 
   postcss-selector-parser@6.0.10:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,3 +12,7 @@ overrides:
   defu: ">=6.1.5"
   vite: ">=8.0.5"
   brace-expansion: ">=1.1.13"
+
+allowBuilds:
+  sharp: false
+  simple-git-hooks: false


### PR DESCRIPTION
Upgrades the package manager to **pnpm 11** properly (superseding the partial Dependabot bump #141, which only changed the devDep and broke the Vercel build with a corepack version-mismatch error).

## Changes
- Bump **both** `packageManager` and the `pnpm` devDep to `11.0.8` (they must match, or corepack errors).
- Regenerate `pnpm-lock.yaml` under pnpm 11 — only the pnpm self-reference changes (no dependency re-resolution).
- pnpm 11 **errors on undeclared build scripts**, so declare the build policy via the new `allowBuilds` model. Both stay **disabled** (no behavior change vs pnpm 10, where they were already ignored):
  - `sharp: false` — ships prebuilt platform binaries (`@img/sharp-*`), so its install script isn't needed.
  - `simple-git-hooks: false` — only installs local git hooks; irrelevant in CI/deploys.

## Why now / context
pnpm 11 turns on `minimumReleaseAge` + `blockExoticSubdeps` by default (we already set both explicitly), and replaces `onlyBuiltDependencies` with `allowBuilds`.

## Verified locally under pnpm 11.0.8
- `pnpm install --frozen-lockfile` (CI path) — exit 0
- `lib:build`, demo `next build` (the nested-pnpm path that fails on a partial bump), `check` (lint+format+typecheck), integration tests — all pass.

After merge, close #141.