### PR TITLE
chore: remove pnpm from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "oxlint": "1.57.0",
     "oxlint-tsgolint": "0.17.4",
     "playwright": "1.58.2",
-    "pnpm": "11.0.8",
     "simple-git-hooks": "2.13.1"
   },
   "simple-git-hooks": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,9 +52,6 @@ importers:
       playwright:
         specifier: 1.58.2
         version: 1.58.2
-      pnpm:
-        specifier: 11.0.8
-        version: 11.0.8
       simple-git-hooks:
         specifier: 2.13.1
         version: 2.13.1
@@ -2444,11 +2441,6 @@ packages:
   playwright@1.58.2:
     resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
     engines: {node: '>=18'}
-    hasBin: true
-
-  pnpm@11.0.8:
-    resolution: {integrity: sha512-TECX4d0tQjcsTn+lp5H/KPx1pITHrBkuZLHfD97xdZS6mC+bT+2a37PHV4RvVlt5mydj+zcz0d4by4LPRmhJEg==}
-    engines: {node: '>=22.13'}
     hasBin: true
 
   postcss-selector-parser@6.0.10:
@@ -4926,8 +4918,6 @@ snapshots:
       playwright-core: 1.58.2
     optionalDependencies:
       fsevents: 2.3.2
-
-  pnpm@11.0.8: {}
 
   postcss-selector-parser@6.0.10:
     dependencies:


### PR DESCRIPTION
Fixes the recurring pnpm version-mismatch that broke the Vercel builds on **#141** and **#148**.

## Root cause
`pnpm` was listed **both** as a devDependency *and* in the `packageManager` field. Dependabot bumps the devDep on its own (e.g. #148: `11.0.8 → 11.1.2`) without touching `packageManager` (`11.0.8`). The demo's build script runs a nested `pnpm run`, which resolves to the devDep binary - and **pnpm 11 hard-errors** when the running version ≠ `packageManager` under corepack. So every Dependabot group run re-breaks the build.

## Fix
Remove `pnpm` from devDependencies. `packageManager` is the single source of truth (corepack / `pnpm/action-setup` / Vercel all read it); the devDep was redundant.

## Verified under pnpm 11.0.8
- `pnpm install --frozen-lockfile` → exit 0
- `pnpm --version` still resolves (via corepack)
- demo `next build` (the failing path) → passes

## Follow-up after merge
`@dependabot recreate` on #148 so its group regenerates without the pnpm devDep bump → Vercel will pass.