### PR TITLE
fix(lint): drop oxlint rules removed in 1.65

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -19,11 +19,9 @@ export default defineConfig({
     jsx: true
   },
   rules: {
-    "import/no-unresolved": "off",
     "no-control-regex": "off",
     "no-unused-expressions": "off",
     "typescript/no-non-null-assertion": "off",
-    "jsx-quotes": ["warn", "prefer-double"],
     "react-hooks/exhaustive-deps": "off"
   },
   ignorePatterns: ["**/node_modules/**", "**/dist/**", "**/.next/**", "**/coverage/**", "**/*.d.ts"]


### PR DESCRIPTION
Unblocks the oxlint bump in #150 (and future ones).

## Problem
oxlint **1.65** removed `jsx-quotes` and `import/no-unresolved`, and now **hard-errors** when the config references unknown rules (1.57 silently tolerated them). So #150's `oxlint 1.57 → 1.65` bump fails the `check` job with *"Failed to parse oxlint configuration file"*.

## Fix
Remove the two dead rules from `oxlint.config.ts`:
- `jsx-quotes` — quote style is handled by oxfmt
- `import/no-unresolved` — was already `"off"`

## Forward-compatible
Verified **0 warnings / 0 errors under both oxlint 1.57 (current) and 1.65**, and full `check` (lint+format+typecheck) passes. So this merges cleanly on main now, and #150's bump works once rebased.

## After merge
`@dependabot rebase` #150 → it picks up the cleaned config → `check` passes → merge.