### PR TITLE
fix(tsconfig): use moduleResolution "Bundler" at the root

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ESNext",
     "module": "ESNext",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "esModuleInterop": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Unblocks the TypeScript/tsgolint bumps in #150.

## Problem
TypeScript removed the legacy `"Node"` (node10) module resolution. The newer `oxlint-tsgolint` (0.22.1) in #150 now rejects it, so the type-aware lint in the `check` job fails with *"Invalid tsconfig — Option `moduleResolution=node10` has been removed"*.

## Fix
The **root** `tsconfig.json` was the only one still on `"Node"` — `packages/lib` and `demos/nextjs` already use `"Bundler"`. Align the root with them (`module` is already `ESNext`, which `Bundler` expects).

## Forward-compatible
Verified full `check` (type-aware lint + format + typecheck) passes under current tooling **and** `oxlint@1.65.0` reports 0 errors.

## After merge
`@dependabot rebase` #150 → it picks up the fixed tsconfig → `check` passes → merge.