### PR TITLE
ci: hands-off releases + richer release notes

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["nextjs-demo"]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,24 @@ jobs:
     outputs:
       published: ${{ steps.changesets.outputs.published }}
     steps:
-      # No persist-credentials:false here: changesets/action pushes the
-      # `changeset-release/main` branch using the persisted GITHUB_TOKEN.
+      # Mint a token from the release GitHub App. Unlike the default
+      # GITHUB_TOKEN, pushes made with it DO trigger other workflows - so the
+      # "Version Packages" PR runs the required CI - and the app is a ruleset
+      # bypass actor, so its version-bump commit satisfies the signed-commits
+      # rule without a manual re-sign.
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      # persist-credentials (default) keeps the app token in git config so
+      # changesets/action pushes `changeset-release/main` as the app.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -63,7 +76,7 @@ jobs:
           # a contributors list) than the Changesets default.
           createGithubReleases: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # Generates npm provenance during `changeset publish`.
           NPM_CONFIG_PROVENANCE: "true"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
       contents: write # version-bump commits, tags, GitHub Releases
       pull-requests: write # open/update the "Version Packages" PR
       id-token: write # npm OIDC trusted publishing + provenance
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
     steps:
       # No persist-credentials:false here: changesets/action pushes the
       # `changeset-release/main` branch using the persisted GITHUB_TOKEN.
@@ -48,11 +50,48 @@ jobs:
 
       # Opens/updates the Version Packages PR; publishes once that PR is merged.
       - name: Create Release PR or publish
+        id: changesets
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           version: pnpm run version-packages
           publish: pnpm run release
+          # Friendlier than the default "Version Packages" commit/title.
+          commit: "chore: version packages"
+          title: "chore: version packages"
+          # The GitHub Release is created by the `release-notes` job below with
+          # richer notes (grouped changes, "by @user in #PR", a compare link and
+          # a contributors list) than the Changesets default.
+          createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Generates npm provenance during `changeset publish`.
           NPM_CONFIG_PROVENANCE: "true"
+
+  # Builds the GitHub Release from conventional commits (matching the format
+  # used before the Changesets migration). Runs only on the publish push - i.e.
+  # when a version was actually released. Deliberately a separate job so this
+  # third-party tool never runs alongside the `id-token` (OIDC) permission.
+  release-notes:
+    needs: release
+    if: needs.release.outputs.published == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the GitHub Release
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0 # full history + tags for the changelog range
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Set node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .node-version
+
+      - name: Create GitHub Release notes
+        run: pnpm dlx changelogithub@14.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          # Scope the token to only what the release needs (the app itself may
+          # hold more): push branches/tags and open the Version Packages PR.
+          permission-contents: write
+          permission-pull-requests: write
 
       # persist-credentials (default) keeps the app token in git config so
       # changesets/action pushes `changeset-release/main` as the app.


### PR DESCRIPTION
Reworks the release pipeline so the "Version Packages" PR runs CI and merges without the manual re-sign, and restores the pre-Changesets release-note format.

## Changes
1. **Hands-off Version Packages PR** - mints a token from the `marsidev-release-bot` GitHub App (`actions/create-github-app-token`, SHA-pinned) and uses it for `checkout` + `changesets/action`. App-token pushes trigger the required CI (the default `GITHUB_TOKEN` does not), and the app is a ruleset **bypass actor**, so its version-bump commit satisfies the `required_signatures` rule. No more manual re-sign.
2. **Richer GitHub Release notes** - `createGithubReleases: false` on `changesets/action` + a separate `release-notes` job that runs `changelogithub` (grouped changes, `by @user in #PR`, compare link, contributors), like v1.4.1 and earlier.
3. **Nicer Version Packages PR** - `commit`/`title` = `chore: version packages`.
4. **Stop bumping the private demo** - `nextjs-demo` added to the Changesets `ignore` list.

## Prerequisites (must be in place BEFORE merging)
- [x] Repo secrets `RELEASE_APP_ID` + `RELEASE_APP_PRIVATE_KEY`
- [x] App added to the `main protection` ruleset bypass list
- [ ] **App installed on `marsidev/react-turnstile`** with Contents + Pull requests read/write -- confirm this, or the next release's token step fails

## Hardening notes
- `release-notes` is a **separate job** with only `contents: write` - `changelogithub` never runs alongside the publish job's `id-token` (OIDC) permission.
- `changelogithub` pinned to `14.0.0`, run via `pnpm dlx` (no lockfile dep), and only after publish - a notes failure can't block the npm release.
- App token is least-privilege (only the two permissions, only this repo).

## Watch on the first release after merge
- `create-github-app-token` succeeds (proves the install) and the Version Packages PR shows CI running + is mergeable without re-signing.
- `changelogithub` notes look right despite the tag-format change (old `vX.Y.Z` vs Changesets' `@marsidev/react-turnstile@x.y.z`). If either misbehaves, revert that piece (app-token -> back to `GITHUB_TOKEN`; notes -> `createGithubReleases: true`).