### PR TITLE
ci: suppress adhoc-packages zizmor finding in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,9 @@ jobs:
       # OIDC trusted publishing needs npm >= 11.5.1. Node 24.x already ships a
       # newer npm, so only upgrade on the rare runner that lags the floor.
       - name: Ensure npm >= 11.5.1
-        run: |
+        # The global npm upgrade is an intentional tooling bump (OIDC trusted
+        # publishing floor), not a lockfile-managed dependency.
+        run: | # zizmor: ignore[adhoc-packages]
           need=11.5.1
           have=$(npm -v)
           [ "$(printf '%s\n%s\n' "$need" "$have" | sort -V | head -n1)" = "$need" ] || npm install -g npm@latest

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -14,3 +14,9 @@ rules:
       # changesets/action pushes the `changeset-release/main` branch using the
       # persisted GITHUB_TOKEN, so persist-credentials must stay enabled here.
       - release.yml
+  adhoc-packages:
+    ignore:
+      # The "Ensure npm >= 11.5.1" step intentionally upgrades npm globally
+      # when the runner's npm lags the OIDC trusted-publishing floor. It's a
+      # tooling upgrade, not a lockfile-managed dependency.
+      - release.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -14,9 +14,3 @@ rules:
       # changesets/action pushes the `changeset-release/main` branch using the
       # persisted GITHUB_TOKEN, so persist-credentials must stay enabled here.
       - release.yml
-  adhoc-packages:
-    ignore:
-      # The "Ensure npm >= 11.5.1" step intentionally upgrades npm globally
-      # when the runner's npm lags the OIDC trusted-publishing floor. It's a
-      # tooling upgrade, not a lockfile-managed dependency.
-      - release.yml


### PR DESCRIPTION
## Why

Dependabot's zizmor-action bump to 0.5.7 (#198) fails its own `zizmor` check: the new action version ships **zizmor v1.26.1**, which adds the [`adhoc-packages`](https://docs.zizmor.sh/audits/#adhoc-packages) audit. That audit flags the `npm install -g npm@latest` fallback in `release.yml` (the "Ensure npm >= 11.5.1" step) as a Low-severity finding, and the job exits with code 12.

The finding is a false positive for our case: that step intentionally upgrades npm globally when the runner's npm lags the OIDC trusted-publishing floor (npm >= 11.5.1). It's a tooling upgrade, not a lockfile-managed dependency.

## What

Add `adhoc-packages: ignore: [release.yml]` to `.github/zizmor.yml`, with a justification comment, alongside the existing `cache-poisoning`/`artipacked` ignores.

Once this merges, #198 should go green after a rebase (`@dependabot rebase`).