### PR TITLE
ci: create version-bump commits via the GitHub API so they're signed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,10 @@ jobs:
     steps:
       # Mint a token from the release GitHub App. Unlike the default
       # GITHUB_TOKEN, pushes made with it DO trigger other workflows - so the
-      # "Version Packages" PR runs the required CI - and the app is a ruleset
-      # bypass actor, so its version-bump commit satisfies the signed-commits
-      # rule without a manual re-sign.
+      # "Version Packages" PR runs the required CI. Note the app's ruleset
+      # bypass does NOT exempt its commits from the signed-commits rule at
+      # merge time (bypass applies to whoever merges, not whoever pushed);
+      # that's what `commitMode: github-api` below solves.
       - name: Generate app token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -77,6 +78,11 @@ jobs:
           # Friendlier than the default "Version Packages" commit/title.
           commit: "chore: version packages"
           title: "chore: version packages"
+          # Create the version-bump commit (and tags) via the GitHub API
+          # instead of the git CLI: API-created commits are signed by GitHub,
+          # so the Version Packages PR passes the ruleset's required-signatures
+          # rule (a git-CLI commit is unsigned and blocks the merge).
+          commitMode: "github-api"
           # The GitHub Release is created by the `release-notes` job below with
           # richer notes (grouped changes, "by @user in #PR", a compare link and
           # a contributors list) than the Changesets default.


### PR DESCRIPTION
## What

Adds `commitMode: "github-api"` to the `changesets/action` step in `release.yml`, and corrects the stale comment about the release app's ruleset bypass.

## Why

The `main protection` ruleset requires signed commits. `changesets/action` creates the "Version Packages" commit via the git CLI, which is unsigned - so every release PR (e.g. #230) is blocked from merging.

The release app's bypass-actor entry doesn't help here: bypass applies to the actor performing the gated operation. The app pushes to `changeset-release/main` (not covered by the ruleset), while the merge into `main` is performed by a maintainer who isn't a bypass actor.

With `commitMode: "github-api"` (supported since the pinned v1.9.0), the action creates commits and tags through the GitHub API, which GitHub signs automatically and attributes to the release app - so Version Packages PRs pass the required-signatures rule.

## Notes

- Once this lands on `main`, the release workflow re-runs and force-updates `changeset-release/main` with a verified commit, unblocking #230.
- No changeset: CI-only change, not user-facing.