### PR TITLE
ci: push release tags explicitly after publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,8 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
-      # persist-credentials (default) keeps the app token in git config so
-      # changesets/action pushes `changeset-release/main` as the app.
+      # persist-credentials (default) keeps the app token in git config so the
+      # "Push release tags" step below can push tags as the app.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
@@ -91,6 +91,14 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # Generates npm provenance during `changeset publish`.
           NPM_CONFIG_PROVENANCE: "true"
+
+      # changesets/action only pushes release tags as part of
+      # createGithubReleases, which is disabled above - so the tag created by
+      # `changeset publish` never reaches GitHub and the `release-notes` job
+      # can't find it. Push it explicitly instead.
+      - name: Push release tags
+        if: steps.changesets.outputs.published == 'true'
+        run: git push origin --tags
 
   # Builds the GitHub Release from conventional commits (matching the format
   # used before the Changesets migration). Runs only on the publish push - i.e.


### PR DESCRIPTION
## What

Adds a `Push release tags` step to `release.yml` that runs `git push origin --tags` when `changesets/action` reports `published == 'true'`, and updates the stale `persist-credentials` comment accordingly.

## Why

`changesets/action` v1.9 only pushes release tags inside its `createGithubReleases` path:

```ts
if (createGithubReleases) {
  ...
  await git.pushTag(tagName);
  await createRelease(octokit, { pkg, tagName });
}
```

This workflow sets `createGithubReleases: false` (GitHub Releases come from changelogithub in the `release-notes` job, since #169), so the tag created by `changeset publish` never reaches GitHub. The 1.5.4 publish exposed it: npm publish succeeded but `release-notes` failed with "Current ref main is not available as tags on GitHub" ([run](https://github.com/marsidev/react-turnstile/actions/runs/30269564724)). The 1.5.4 tag was pushed manually as a one-off; this makes future releases hands-off again.

The checkout persists the release-app token, so the push runs as the app. Tags aren't covered by the `main protection` ruleset, so no signature requirement applies.

## Notes

- No changeset: CI-only change, not user-facing.