### PR TITLE
ci: drop paths-ignore from the pull_request trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,12 @@ on:
       - "**.md"
       - "**.mdx"
 
+  # No paths-ignore here: check/e2e-test/integration-test are required status
+  # checks, and a path-filtered workflow never reports them - a docs-only PR
+  # would show them as "Expected" forever and be unmergeable.
   pull_request:
     branches:
       - main
-
-    paths-ignore:
-      - "docs/**"
-      - "**.md"
-      - "**.mdx"
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

Removes the `paths-ignore` filter (`docs/**`, `**.md`, `**.mdx`) from `ci.yml`'s `pull_request` trigger. The filter stays on the `push` trigger, where no required checks are involved.

## Why

`check`, `e2e-test` and `integration-test` are required status checks in the `main protection` ruleset. With the path filter in place, a docs-only PR (e.g. #240, which only touches `README.md`) never triggers CI - so the required checks stay in "Expected - Waiting for status to be reported" forever and the PR can't be merged. An empty commit doesn't help either: for `pull_request` events the filter is evaluated against the PR's full changed-file set.

Path filters and required status checks fundamentally don't compose. The cost of removing the filter is a few minutes of Actions time on the rare docs-only PR; the benefit is that merges never wedge on phantom checks.

## Notes

- `zizmor.yml` already runs unfiltered on every PR, which is why it wasn't stuck on #240.
- After this merges, #240 just needs its branch updated (to pick up the fixed workflow via a `synchronize` event) and its checks will run.
- No changeset: CI-only change, not user-facing.