### PR TITLE
fix: show widget after calling `execute()` in execute mode

### DIFF
--- a/.changeset/quiet-pillows-jump.md
+++ b/.changeset/quiet-pillows-jump.md
@@ -1,0 +1,7 @@
+---
+"@marsidev/react-turnstile": patch
+---
+
+fix: show widget after calling `execute()` in execute mode (regression from #229)
+
+Previously, calling `execute()` re-applied the container style via `getContainerStyle()`, which returned the invisible style whenever `options.execution === "execute"`. The widget stayed hidden even after being executed. Now the container is made visible (per `size`/`appearance`) when `execute()` is called.

--- a/packages/lib/src/lib.tsx
+++ b/packages/lib/src/lib.tsx
@@ -69,18 +69,21 @@ export const Turnstile = forwardRef<TurnstileInstance | undefined, TurnstileProp
 
   const widgetSize = options.size;
 
-  const getContainerStyle = useCallback(() => {
-    if (typeof widgetSize === "undefined") return {};
-    if (options.execution === "execute") return CONTAINER_STYLE_SET.invisible;
+  const getContainerStyle = useCallback(
+    (ignoreExecution = false) => {
+      if (typeof widgetSize === "undefined") return {};
+      if (!ignoreExecution && options.execution === "execute") return CONTAINER_STYLE_SET.invisible;
 
-    const baseStyle = CONTAINER_STYLE_SET[widgetSize];
+      const baseStyle = CONTAINER_STYLE_SET[widgetSize];
 
-    if (options.appearance === "interaction-only") {
-      return { ...baseStyle, height: "auto" };
-    }
+      if (options.appearance === "interaction-only") {
+        return { ...baseStyle, height: "auto" };
+      }
 
-    return baseStyle;
-  }, [options.execution, widgetSize, options.appearance]);
+      return baseStyle;
+    },
+    [options.execution, widgetSize, options.appearance]
+  );
 
   const [containerStyle, setContainerStyle] = useState(getContainerStyle());
   const containerRef = useRef<HTMLElement | null>(null);
@@ -370,7 +373,7 @@ export const Turnstile = forwardRef<TurnstileInstance | undefined, TurnstileProp
         }
 
         turnstile.execute(containerRef.current);
-        setContainerStyle(getContainerStyle());
+        setContainerStyle(getContainerStyle(true));
       },
 
       isExpired() {


### PR DESCRIPTION
Previously, calling `execute()` re-applied the container style via `getContainerStyle()`, which returned the invisible style whenever `options.execution === "execute"`. The widget stayed hidden even after being executed. Now the container is made visible (per `size`/`appearance`) when `execute()` is called.

Regression introduced by #229, fixes #244