### PR TITLE
feat: update server-side validation (siteverify) types

### DIFF
--- a/.changeset/curly-donuts-repeat.md
+++ b/.changeset/curly-donuts-repeat.md
@@ -1,0 +1,5 @@
+---
+"@marsidev/react-turnstile": minor
+---
+
+Update server-side validation (siteverify) types to match the current Cloudflare docs: add a new `TurnstileServerValidationRequest` type, add `metadata.ephemeral_id` (Enterprise) to `TurnstileServerValidationResponse`, and mark the `invalid-widget-id` and `invalid-parsed-secret` error codes as no longer documented by Cloudflare (kept for backwards compatibility).

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -6,6 +6,7 @@ export type {
   TurnstileProps,
   TurnstileInstance,
   TurnstileServerValidationErrorCode,
+  TurnstileServerValidationRequest,
   TurnstileServerValidationResponse,
   Theme as TurnstileTheme,
   TurnstileLangCode,

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -295,6 +295,21 @@ export type TurnstileLangCode =
   | (string & {});
 
 /**
+ * Request parameters for the Cloudflare Turnstile server-side validation (siteverify) endpoint.
+ * See {@link https://developers.cloudflare.com/turnstile/get-started/server-side-validation the docs} for more info.
+ */
+export interface TurnstileServerValidationRequest {
+  /** The widget's secret key. */
+  secret: string;
+  /** The response (token) provided by the Turnstile widget on the client side. */
+  response: string;
+  /** The visitor's IP address. */
+  remoteip?: string;
+  /** A UUID to be associated with the response, which allows the validation request to be safely retried. */
+  idempotency_key?: string;
+}
+
+/**
  * Server-side validation response from Cloudflare Turnstile.
  * See {@link https://developers.cloudflare.com/turnstile/get-started/server-side-validation the docs} for more info.
  */
@@ -311,8 +326,13 @@ export interface TurnstileServerValidationResponse {
   action?: string;
   /** The customer data passed to the widget on the client side. This can be used by the customer to convey state. It is integrity protected by modifications from an attacker. */
   cdata?: string;
-  /** Whether or not an interactive challenge was issued by Cloudflare */
-  metadata?: { interactive: boolean };
+  /** Additional metadata about the solved challenge. */
+  metadata?: {
+    /** Whether or not an interactive challenge was issued by Cloudflare. No longer documented by Cloudflare. */
+    interactive?: boolean;
+    /** An identifier shared across challenges solved on the same device (Enterprise only). See {@link https://developers.cloudflare.com/turnstile/additional-configuration/ephemeral-id/ the Ephemeral IDs docs} for more info. */
+    ephemeral_id?: string;
+  };
   /** Error messages returned */
   messages?: string[];
 }
@@ -330,9 +350,9 @@ export type TurnstileServerValidationErrorCode =
   | "missing-input-response"
   /**  The response parameter is invalid or has expired. */
   | "invalid-input-response"
-  /**  The widget ID extracted from the parsed site secret key was invalid or did not exist. */
+  /**  The widget ID extracted from the parsed site secret key was invalid or did not exist. No longer documented by Cloudflare, kept for backwards compatibility. */
   | "invalid-widget-id"
-  /**  The secret extracted from the parsed site secret key was invalid. */
+  /**  The secret extracted from the parsed site secret key was invalid. No longer documented by Cloudflare, kept for backwards compatibility. */
   | "invalid-parsed-secret"
   /**  The request was rejected because it was malformed. */
   | "bad-request"


### PR DESCRIPTION
Syncs the siteverify types with the current Cloudflare [server-side validation docs](https://developers.cloudflare.com/turnstile/get-started/server-side-validation/). Closes #209.

- Add exported `TurnstileServerValidationRequest` type (`secret`, `response`, `remoteip?`, `idempotency_key?`)
- Extend `TurnstileServerValidationResponse.metadata` to `{ interactive?: boolean; ephemeral_id?: string }` - `ephemeral_id` is Enterprise-only ([Ephemeral IDs](https://developers.cloudflare.com/turnstile/additional-configuration/ephemeral-id/)); `interactive` is no longer documented by Cloudflare
- Mark `invalid-widget-id` / `invalid-parsed-secret` error codes as no longer documented (kept in the union for backwards compatibility)

Types-only change, no runtime impact. Changeset: minor (new exported type).