### PR TITLE
docs: sync JSDoc and types with current Cloudflare Turnstile docs

### DIFF
--- a/.changeset/tidy-pandas-smile.md
+++ b/.changeset/tidy-pandas-smile.md
@@ -1,0 +1,5 @@
+---
+"@marsidev/react-turnstile": patch
+---
+
+Sync JSDoc and types with the current Cloudflare Turnstile docs: fix the documented `retry-interval` default (8000 ms), document that `language` also accepts language-country codes (e.g. `en-US`), add the missing language codes (`bg`, `vi` and language-country variants) to `TurnstileLangCode`, document the client-side error code families on `onError`, and clarify that the `"invisible"` size is a library-only convention.

--- a/packages/lib/src/turnstile.ts
+++ b/packages/lib/src/turnstile.ts
@@ -58,6 +58,8 @@ export type Theme = "auto" | "light" | "dark";
 /**
  * The widget size.
  * Can take the following values: normal, compact, flexible, invisible.
+ * Note: the values officially accepted by Turnstile are "normal", "flexible" and "compact";
+ * "invisible" is a library-only convention (it is not forwarded to Turnstile).
  */
 export type WidgetSize = "normal" | "compact" | "flexible" | "invisible";
 
@@ -179,13 +181,14 @@ export interface RenderParameters {
 
   /**
    * Optional. Duration in milliseconds before the widget automatically retries.
-   * @default 2000
+   * @default 8000
    */
   "retry-interval"?: number | undefined;
 
   /**
    * Optional. The language picked by the customer (may not be supported).
-   * This must be a valid ISO 639-1 country code, or "auto".
+   * This must be a valid ISO 639-1 two-letter language code (e.g. "en"), a language-country code (e.g. "en-US"), or "auto".
+   * See {@link https://developers.cloudflare.com/turnstile/reference/supported-languages/ the supported languages} for more info.
    * @default "auto"
    */
   language?: string | undefined;

--- a/packages/lib/src/turnstile.ts
+++ b/packages/lib/src/turnstile.ts
@@ -164,8 +164,8 @@ export interface RenderParameters {
 
   /**
    * Optional. The size of the Turnstile widget.
-   * Accepted values: "normal", "compact", "flexible", "invisible"
-   * Note: "invisible" is only to be used with invisible widgets
+   * Accepted values: "normal", "compact", "flexible".
+   * Note: "invisible" is a library-only convention for invisible widgets; it is omitted from the config sent to Turnstile.
    * @see WidgetSize
    * @default "normal"
    */

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -80,6 +80,8 @@ export interface ComponentRenderOptions extends Pick<
    * Accepted values: "normal", "compact", "flexible", "invisible".
    * Normal: 300x65px, compact: 150x140px, flexible: 100% width (min: 300px) x 65px.
    * Invisible will show no widget and is only to be used with invisible type widgets.
+   * Note: the values officially accepted by Turnstile are "normal", "flexible" and "compact"; "invisible" is a
+   * library-only convention (it is not forwarded to Turnstile).
    * @default "normal"
    */
   size?: Turnstile.WidgetSize;
@@ -172,7 +174,12 @@ export interface TurnstileProps extends Omit<React.HTMLAttributes<HTMLDivElement
 
   /**
    * Callback invoked when there is an error (e.g. network error or the challenge failed). The callback is passed an error code.
-   * Refer to [Client-side errors](https://developers.cloudflare.com/turnstile/troubleshooting/client-side-errors/).
+   *
+   * Common error code families: `110xxx` (invalid or unauthorized sitekey/domain), `110600` (challenge timed out),
+   * `110620` (interaction timed out), `200100` (visitor clock skew or cached page), `200500` (challenge iframe could not load),
+   * `300xxx` and `600xxx` (generic challenge failures), `400xxx` (sitekey validation issues).
+   *
+   * Refer to [Client-side error codes](https://developers.cloudflare.com/turnstile/troubleshooting/client-side-errors/error-codes/) for the full list.
    */
   onError?: Turnstile.RenderParameters["error-callback"];
 
@@ -253,41 +260,77 @@ export type ContainerSizeSet = {
 export type TurnstileLangCode =
   | "ar"
   | "ar-EG"
+  | "bg"
+  | "bg-BG"
   | "cs"
+  | "cs-CZ"
   | "da"
+  | "da-DK"
   | "de"
+  | "de-DE"
   | "el"
+  | "el-GR"
   | "en"
+  | "en-US"
   | "es"
+  | "es-ES"
   | "fa"
+  | "fa-IR"
   | "fi"
+  | "fi-FI"
   | "fr"
+  | "fr-FR"
   | "he"
+  | "he-IL"
   | "hi"
+  | "hi-IN"
   | "hr"
+  | "hr-HR"
   | "hu"
+  | "hu-HU"
   | "id"
+  | "id-ID"
   | "it"
+  | "it-IT"
   | "ja"
+  | "ja-JP"
   | "ko"
+  | "ko-KR"
   | "lt"
-  | "nl"
+  | "lt-LT"
   | "ms"
+  | "ms-MY"
   | "nb"
+  | "nb-NO"
+  | "nl"
+  | "nl-NL"
   | "pl"
+  | "pl-PL"
   | "pt"
   | "pt-BR"
   | "ro"
+  | "ro-RO"
   | "ru"
+  | "ru-RU"
   | "sk"
+  | "sk-SK"
   | "sl"
+  | "sl-SI"
   | "sr"
+  | "sr-BA"
   | "sv"
+  | "sv-SE"
   | "th"
+  | "th-TH"
   | "tl"
+  | "tl-PH"
   | "tlh"
   | "tr"
+  | "tr-TR"
   | "uk"
+  | "uk-UA"
+  | "vi"
+  | "vi-VN"
   | "zh"
   | "zh-CN"
   | "zh-TW"


### PR DESCRIPTION
Syncs JSDoc and types with the current Cloudflare Turnstile reference. Closes #211.

- Fix the documented `retry-interval` default in `RenderParameters` (8000 ms, was 2000; `types.ts` was already correct)
- `language`: document that it accepts an ISO 639-1 two-letter code **or** a language-country code (e.g. `en-US`), with a link to the [supported languages](https://developers.cloudflare.com/turnstile/reference/supported-languages/)
- `TurnstileLangCode`: add `bg`, `vi` and the language-country variants from the official table (autocomplete-only, the union still accepts `string & {}`)
- `onError`: document the client-side [error code](https://developers.cloudflare.com/turnstile/troubleshooting/client-side-errors/error-codes/) families
- `size`: note that the officially accepted values are `normal | flexible | compact`, and `"invisible"` is a library-only convention (not forwarded to Turnstile)

JSDoc/types only, no runtime changes. Changeset: patch.