### PR TITLE
Pin changesets/action to v1.9.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@ updates:
       github-actions:
         patterns:
           - "*"
+        # changesets/action's major is coupled to the Changesets CLI major
+        # (v2 requires CLI v3 and renamed every input), so it needs a manual
+        # migration. Keep it out of the batch so it arrives as its own PR.
+        exclude-patterns:
+          - "changesets/action"
 
   # npm/pnpm dependencies across the workspace.
   - package-ecosystem: "npm"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,12 @@ jobs:
       # Opens/updates the Version Packages PR; publishes once that PR is merged.
       - name: Create Release PR or publish
         id: changesets
-        uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v2.1.0
+        # Pinned to v1: changesets/action v2 requires Changesets CLI v3 and
+        # aborts on CLI v2 (this repo is on 2.31.1). v2 also renamed every
+        # input below (version -> version-script, commit -> commit-message,
+        # commitMode -> push-with-git-cli, ...), so moving up means bumping
+        # the CLI major and rewriting this block together.
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: pnpm run version-packages
           publish: pnpm run release


### PR DESCRIPTION
`changesets/action` v2 requires Changesets CLI v3 and aborts on CLI v2. This repo is on 2.31.1, so the release job has failed on every push to `main` since #265 bumped the action, and #269's changeset never produced a Version Packages PR.

v2 also renamed the inputs this workflow passes (`version`, `publish`, `commit`, `title`, `commitMode`, `createGithubReleases`), so they were being ignored. Pinning back to v1.9.0 restores the last known-good state. Moving to v2 means bumping the CLI major and rewriting the block together, which should be its own change.

Dependabot's `github-actions` group batches every action with `patterns: "*"`, which is how the major landed inside a routine bump PR. `changesets/action` is now excluded from that group, so future bumps still arrive, just as their own reviewable PR.
