### PR TITLE
ci: build release notes from the changelog

### DIFF
--- a/.github/scripts/release-notes.mjs
+++ b/.github/scripts/release-notes.mjs
@@ -1,0 +1,97 @@
+// Creates one GitHub Release per package published by the release job, using
+// that package's CHANGELOG.md entry as the body.
+//
+// The changelog is the single source for release notes: changesets writes it
+// from the changeset files, and @changesets/changelog-github already adds the
+// PR link, the commit link and the contributor credit.
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { GH_TOKEN, REPO, PUBLISHED_PACKAGES } = process.env;
+
+if (!GH_TOKEN) throw new Error("GH_TOKEN is required");
+if (!REPO) throw new Error("REPO is required");
+
+const published = JSON.parse(PUBLISHED_PACKAGES || "[]");
+if (published.length === 0) {
+  console.log("No published packages, nothing to release.");
+  process.exit(0);
+}
+
+/** Map every workspace package name to its directory. */
+function findPackages(dir, out = new Map(), depth = 0) {
+  if (depth > 3) return out;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory() && entry.name !== "node_modules" && !entry.name.startsWith(".")) {
+      findPackages(join(dir, entry.name), out, depth + 1);
+    }
+  }
+  try {
+    const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
+    if (pkg.name) out.set(pkg.name, dir);
+  } catch {}
+  return out;
+}
+
+const dirs = findPackages(process.cwd());
+
+/**
+ * Pull the `## <version>` section out of a changelog, stopping at the next
+ * heading of the same level.
+ */
+function changelogEntry(changelog, version) {
+  const lines = changelog.split("\n");
+  const start = lines.findIndex(l => l.trim() === `## ${version}`);
+  if (start === -1) return undefined;
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex(l => l.startsWith("## "));
+  return (end === -1 ? rest : rest.slice(0, end)).join("\n").trim();
+}
+
+const tmp = mkdtempSync(join(tmpdir(), "release-notes-"));
+
+for (const { name, version } of published) {
+  const tag = `${name}@${version}`;
+  const dir = dirs.get(name);
+  if (!dir) throw new Error(`${name} is not a workspace package`);
+
+  const entry = changelogEntry(readFileSync(join(dir, "CHANGELOG.md"), "utf8"), version);
+  if (!entry) throw new Error(`no changelog entry for ${tag}`);
+
+  // Link back to the diff against the previous tag for this package, the way
+  // the previous notes did. Only added when a previous tag exists.
+  let body = entry;
+  const previous = execFileSync("git", ["tag", "--list", `${name}@*`, "--sort=-v:refname"], {
+    encoding: "utf8"
+  })
+    .split("\n")
+    .map(t => t.trim())
+    .filter(t => t && t !== tag)[0];
+
+  if (previous) {
+    const compare = `https://github.com/${REPO}/compare/${previous}...${tag}`;
+    body += `\n\n##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](${compare})`;
+  }
+
+  const notes = join(tmp, `${version}.md`);
+  writeFileSync(notes, body);
+
+  const args = [
+    "release",
+    "create",
+    tag,
+    "--repo",
+    REPO,
+    "--title",
+    tag,
+    "--notes-file",
+    notes,
+    "--verify-tag"
+  ];
+  if (version.includes("-")) args.push("--prerelease");
+
+  console.log(`Creating release ${tag}`);
+  execFileSync("gh", args, { stdio: "inherit", env: { ...process.env, GH_TOKEN } });
+}

--- a/.github/scripts/release-notes.mjs
+++ b/.github/scripts/release-notes.mjs
@@ -50,6 +50,19 @@ function changelogEntry(changelog, version) {
   return (end === -1 ? rest : rest.slice(0, end)).join("\n").trim();
 }
 
+/** Whether a release already exists for this tag. */
+function exists(tag) {
+  try {
+    execFileSync("gh", ["release", "view", tag, "--repo", REPO, "--json", "tagName"], {
+      stdio: "pipe",
+      env: { ...process.env, GH_TOKEN }
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 const tmp = mkdtempSync(join(tmpdir(), "release-notes-"));
 
 for (const { name, version } of published) {
@@ -78,20 +91,16 @@ for (const { name, version } of published) {
   const notes = join(tmp, `${version}.md`);
   writeFileSync(notes, body);
 
-  const args = [
-    "release",
-    "create",
-    tag,
-    "--repo",
-    REPO,
-    "--title",
-    tag,
-    "--notes-file",
-    notes,
-    "--verify-tag"
-  ];
-  if (version.includes("-")) args.push("--prerelease");
+  // Re-running the job must converge rather than fail on a release that is
+  // already there, so update an existing one instead of creating it twice.
+  const prerelease = version.includes("-");
+  const args = exists(tag)
+    ? ["release", "edit", tag, `--prerelease=${prerelease}`]
+    : ["release", "create", tag, "--verify-tag", ...(prerelease ? ["--prerelease"] : [])];
 
-  console.log(`Creating release ${tag}`);
-  execFileSync("gh", args, { stdio: "inherit", env: { ...process.env, GH_TOKEN } });
+  console.log(`${args[1] === "edit" ? "Updating" : "Creating"} release ${tag}`);
+  execFileSync("gh", [...args, "--repo", REPO, "--title", tag, "--notes-file", notes], {
+    stdio: "inherit",
+    env: { ...process.env, GH_TOKEN }
+  });
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
       id-token: write # npm OIDC trusted publishing + provenance
     outputs:
       published: ${{ steps.changesets.outputs.published }}
+      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
     steps:
       # Mint a token from the release GitHub App. Unlike the default
       # GITHUB_TOKEN, pushes made with it DO trigger other workflows - so the
@@ -127,10 +128,10 @@ jobs:
             git push origin "refs/tags/$tag"
           done
 
-  # Builds the GitHub Release from conventional commits (matching the format
-  # used before the Changesets migration). Runs only on the publish push - i.e.
-  # when a version was actually released. Deliberately a separate job so this
-  # third-party tool never runs alongside the `id-token` (OIDC) permission.
+  # Publishes the GitHub Release for each package that was just released. Runs
+  # only on the publish push - i.e. when a version was actually released - and
+  # stays a separate job so it never runs alongside the `id-token` (OIDC)
+  # permission the publish job needs.
   release-notes:
     needs: release
     if: needs.release.outputs.published == 'true'
@@ -140,18 +141,23 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0 # full history + tags for the changelog range
+          fetch-depth: 0 # tags, so the notes can link to a compare range
           persist-credentials: false
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Set node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
 
-      - name: Create GitHub Release notes
-        run: pnpm dlx changelogithub@14.0.0
+      # The release body is the package's CHANGELOG.md entry for the published
+      # version, which changesets builds from the changeset files (with PR
+      # links and contributor credit via @changesets/changelog-github). Keeping
+      # the notes and the changelog on the same source avoids the previous
+      # setup, where notes were derived from commit subjects and a PR title
+      # without a conventional-commit prefix produced "No significant changes".
+      - name: Create GitHub Releases from the changelog
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PUBLISHED_PACKAGES: ${{ needs.release.outputs.publishedPackages }}
+        run: node .github/scripts/release-notes.mjs


### PR DESCRIPTION
The `release-notes` job derived the GitHub Release body from commit subjects via `changelogithub`, which groups by conventional-commit type. `main` squash-merges, so the commit subject is the PR title, and a PR without a `feat:`/`fix:` prefix contributes nothing. That is why [1.6.1](https://github.com/marsidev/react-turnstile/releases/tag/@marsidev/react-turnstile@1.6.1) shipped as "No significant changes" even though it carried a real fix.

The body now comes from the package's `CHANGELOG.md` entry for the published version. Changesets already writes that from the changeset files, and `@changesets/changelog-github` adds the PR link, the commit link and contributor credit, so the notes and the changelog stop being two sources for the same thing and no longer depend on how a PR was titled.

`.github/scripts/release-notes.mjs` walks the packages published by the release job, extracts each one's changelog section, appends a compare link against that package's previous tag, and creates the release with `gh release create --verify-tag`. A missing changelog entry fails the job instead of publishing empty notes.

### Tag handling is deliberately untouched

`createGithubReleases` stays `false`. Enabling it would hand tags to the action, and under `commitMode: github-api` its `pushTag` downgrades failures to a warning:

```ts
async pushTag(tag: string) {
  if (this.octokit) {
    return this.octokit.rest.git.createRef({ ... }).catch((err) => {
      core.warning(`Failed to create tag ${tag}: ${err.message}`)
    })
  }
  await exec("git", ["push", "origin", tag], { cwd: this.cwd })
}
```

That is the same silent tag loss that hit 1.5.4 and 1.5.5, which the guarded "Push release tags" step exists to catch. It keeps owning tags.

### Verification

Simulated the job against 1.6.1 with the `gh` call stubbed: the generated body is byte-identical to the notes currently on that release, including the previous tag it resolves for the compare link. Changelog extraction also checked against 1.6.0 and 1.5.5 (neither bleeds into the next section) and against a version that does not exist (returns nothing, which the script turns into a hard failure).

End-to-end behaviour can only be confirmed on the next real release.

### Trade-off

Emoji section headers and grouping by change type are gone. The full changeset description is there instead.
