### PR TITLE
ci: notice a broken release instead of waiting for someone to look

### DIFF
--- a/.github/scripts/check-action-inputs.mjs
+++ b/.github/scripts/check-action-inputs.mjs
@@ -1,0 +1,73 @@
+// Fails when a workflow passes a `with:` key that the pinned action version
+// does not declare.
+//
+// GitHub only warns about unknown inputs ("Unexpected input(s) ..."), so the
+// step keeps running with its defaults. That is how the changesets/action
+// v1 -> v2 bump silently dropped `version` and `publish`: the release job would
+// have gone green while doing nothing. A red check on the PR is the only place
+// this is cheap to catch.
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse } from "yaml";
+
+const WORKFLOWS = ".github/workflows";
+const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+
+/** action.yml (or action.yaml) for `owner/repo@ref`, or null for a local action. */
+const cache = new Map();
+async function actionInputs(uses) {
+  if (cache.has(uses)) return cache.get(uses);
+
+  const [path, ref] = uses.split("@");
+  const [owner, repo, ...subdir] = path.split("/");
+  const prefix = subdir.length > 0 ? `${subdir.join("/")}/` : "";
+
+  let manifest;
+  for (const name of ["action.yml", "action.yaml"]) {
+    const url = `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${prefix}${name}`;
+    const res = await fetch(url, token ? { headers: { authorization: `Bearer ${token}` } } : {});
+    if (res.ok) {
+      manifest = parse(await res.text());
+      break;
+    }
+    if (res.status !== 404) throw new Error(`${url} -> HTTP ${res.status}`);
+  }
+  if (!manifest) throw new Error(`no action manifest found for ${uses}`);
+
+  const inputs = new Set(Object.keys(manifest.inputs ?? {}));
+  cache.set(uses, inputs);
+  return inputs;
+}
+
+const problems = [];
+
+for (const file of readdirSync(WORKFLOWS).filter(f => /\.ya?ml$/.test(f))) {
+  const workflow = parse(readFileSync(join(WORKFLOWS, file), "utf8"));
+
+  for (const [jobName, job] of Object.entries(workflow.jobs ?? {})) {
+    for (const step of job.steps ?? []) {
+      // Local actions and docker:// references have no manifest to fetch.
+      if (!step.uses || step.uses.startsWith(".") || step.uses.startsWith("docker://")) continue;
+      if (!step.with) continue;
+
+      const declared = await actionInputs(step.uses);
+      const unknown = Object.keys(step.with).filter(key => !declared.has(key));
+
+      if (unknown.length > 0) {
+        problems.push({ file, jobName, uses: step.uses, unknown });
+      }
+    }
+  }
+}
+
+if (problems.length > 0) {
+  for (const { file, jobName, uses, unknown } of problems) {
+    const list = unknown.join(", ");
+    console.error(`::error file=${WORKFLOWS}/${file}::${jobName}: ${uses} does not accept ${list}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `Every workflow input is declared by its pinned action (${cache.size} actions checked).`
+);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,13 @@ jobs:
       - name: Check
         run: pnpm run check
 
+      # Kept out of `pnpm check` because it needs network access: it fetches
+      # each pinned action's manifest to confirm the inputs we pass exist.
+      - name: Check workflow action inputs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/check-action-inputs.mjs
+
   e2e-test:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,3 +161,50 @@ jobs:
           REPO: ${{ github.repository }}
           PUBLISHED_PACKAGES: ${{ needs.release.outputs.publishedPackages }}
         run: node .github/scripts/release-notes.mjs
+
+  # This workflow only runs on push to main and nothing watches it, so a broken
+  # release is invisible: in August 2026 it failed on five consecutive pushes
+  # over six days before anyone noticed, and a merged changeset never reached
+  # npm. Turn that silence into an issue.
+  report-failure:
+    needs: [release, release-notes]
+    if: ${{ always() && (needs.release.result == 'failure' || needs.release-notes.result == 'failure') }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open an issue for the failed release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          body=$(cat <<EOF
+          The release workflow failed, so nothing was versioned or published.
+
+          - Commit: \`$SHA\`
+          - Run: $RUN_URL
+
+          Every later push to \`main\` fails the same way until this is fixed, and
+          any merged changeset stays unreleased in the meantime.
+          EOF
+          )
+
+          gh label create release-failure \
+            --repo "$REPO" \
+            --color B60205 \
+            --description "The release workflow failed" \
+            --force
+
+          existing=$(gh issue list --repo "$REPO" --state open --label release-failure \
+            --limit 1 --json number -q '.[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" --body "$body"
+          else
+            gh issue create --repo "$REPO" --title "Release failed on ${SHA:0:7}" \
+              --label release-failure --body "$body"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,17 +179,30 @@ jobs:
           REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           SHA: ${{ github.sha }}
+          FAILED_JOB: ${{ needs.release.result == 'failure' && 'release' || 'release-notes' }}
+          # Whether npm publish already went through. `release` can fail after
+          # publishing (the tag push runs later), and `release-notes` only runs
+          # once it has, so the job name alone does not say what happened.
+          PUBLISHED: ${{ needs.release.outputs.published }}
+          PUBLISHED_PACKAGES: ${{ needs.release.outputs.publishedPackages }}
         run: |
           set -euo pipefail
 
+          if [ "${PUBLISHED:-}" = "true" ]; then
+            packages=$(echo "${PUBLISHED_PACKAGES:-[]}" |
+              jq -r '[.[] | "\(.name)@\(.version)"] | join(", ")')
+            state="Already published to npm: \`$packages\`. The failure is after publishing, so re-running the publish is not the fix."
+          else
+            state="Nothing was versioned or published. Every later push to \`main\` fails the same way until this is fixed, and any merged changeset stays unreleased."
+          fi
+
           body=$(cat <<EOF
-          The release workflow failed, so nothing was versioned or published.
+          The release workflow failed in the \`$FAILED_JOB\` job.
+
+          $state
 
           - Commit: \`$SHA\`
           - Run: $RUN_URL
-
-          Every later push to \`main\` fails the same way until this is fixed, and
-          any merged changeset stays unreleased in the meantime.
           EOF
           )
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "oxlint": "1.79.0",
     "oxlint-tsgolint": "7.0.2001",
     "playwright": "1.62.1",
-    "simple-git-hooks": "2.13.1"
+    "simple-git-hooks": "2.13.1",
+    "yaml": "2.9.0"
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm exec nano-staged"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,9 @@ importers:
       simple-git-hooks:
         specifier: 2.13.1
         version: 2.13.1
+      yaml:
+        specifier: 2.9.0
+        version: 2.9.0
 
   demos/nextjs:
     dependencies:


### PR DESCRIPTION
The release workflow only runs on push to `main` and nothing watches it. In August 2026 it failed on five consecutive pushes over six days before anyone noticed, and #269's changeset sat unreleased the whole time. Nothing in the repo would have said so.

Two guards, one for each way a release goes wrong.

### A red run that nobody reads

`report-failure` opens an issue when the release job fails, or comments on the open one so repeated failures do not pile up new issues. It runs on `needs.*.result == 'failure'` rather than plain `failure()`, so a skipped `release-notes` job does not swallow it.

The body says whether npm publish already went through, taken from the release job's `published` output rather than from which job failed. Both jobs can fail after publishing: `release-notes` only runs once packages are published, and `release` pushes tags after `changeset publish`. Telling a responder that nothing was published when it was sends them looking for the wrong thing, or worse, re-running the publish.

### A green run that quietly does nothing

This is the likelier failure after a dependency bump, and it has no red run to notice. GitHub only *warns* about unknown `with:` keys, so an action that renames its inputs keeps going with its defaults:

```
Unexpected input(s) 'version', 'publish', 'commit', 'title', 'commitMode', 'createGithubReleases',
valid inputs are ['github-token', 'publish-script', 'version-script', ...]
```

That is the real changesets/action v2 log. With the CLI bumped too, that run would have gone **green** with no version script and no publish script: no Version Packages PR, no npm publish, no error.

`check-action-inputs.mjs` resolves every pinned action's manifest at its pinned SHA and fails when a workflow passes a key the action does not declare. It runs inside the required `check` job, so it gates merges. It lives outside `pnpm check` because it needs network access.

### Verification

Pointed `release.yml` at the v2.1.0 SHA and ran it:

```
::error file=.github/workflows/release.yml::release: changesets/action@198f833 does not accept
version, publish, commit, title, commitMode, createGithubReleases
exit=1
```

Exactly the six inputs from the real log. Back on v1.9.0 it passes, 6 actions checked.

`report-failure`'s script was extracted from the parsed workflow and run against a stubbed `gh` in both states: no open issue (creates, title `Release failed on 1d53766`) and an existing one (comments instead). The body renders with literal backticks and expanded variables.

### Why now

This lands before the changesets v3 migration (#272 + #274 + #276), which cannot be tested before merging because CI never exercises the release path. These guards do not prevent that migration from breaking. They make sure it is noticed the same day instead of six days later.

Adds `yaml` as a root devDependency for parsing workflow and action manifests.
